### PR TITLE
Revised README with better install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,0 @@
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control?
-#
-# Pods/
-

--- a/README.md
+++ b/README.md
@@ -1,42 +1,38 @@
 defaultbrowser
 ==============
 
-Command line script for getting and setting a default browser (HTTP handler) in Mac OS X.
+Command line tool for setting the default browser (HTTP handler) in macOS X.
 
-As there seems no other elegant way of doing it you need some Objective-C code.
+Install
+-------
 
-The code uses Launch Services. More info on 
-[Launch Services Reference](https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/Reference/reference.html)
-
-
-Build
------
-1. Build it.
+Build it:
 
 ```
-cd defaultbrowser
 xcodebuild -project defaultbrowser.xcodeproj -alltargets -configuration Release
 ```
 
-2. Move it into your path (replace ~/bin to whatever you like)
+Move it into your executable path:
 
 ```
-cp build/Release/defaultbrowser ~/bin/
+cp build/Release/defaultbrowser /usr/local/bin/
 ```
 
 Usage
 -----
 
-Open the XCode project and build it or download the build/defaultbrowser and put it somewhere
-in your path. `chmod +x defaultbrowser` is probably also necessary.
-
-You can set the default browser with:
+Set the default browser with:
 
 ```
 defaultbrowser -set chrome
 ```
 
-Running defaultbrowser without arguments shows the current setting.
+Running `defaultbrowser` without arguments shows the current setting.
+
+How does it work?
+-----------------
+
+The code uses the [macOS Launch Services API](https://developer.apple.com/documentation/coreservices/launch_services).
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Build
 -----
 1. Build it.
 
-`
+```
 cd defaultbrowser
 xcodebuild -project defaultbrowser.xcodeproj -alltargets -configuration Release
-`
+```
 
 2. Move it into your path (replace ~/bin to whatever you like)
 
-`cp build/Release/defaultbrowser ~/bin/`
+```
+cp build/Release/defaultbrowser ~/bin/
+```
 
 Usage
 -----
@@ -30,6 +32,8 @@ in your path. `chmod +x defaultbrowser` is probably also necessary.
 
 You can set the default browser with:
 
-    defaultbrowser -set chrome
+```
+defaultbrowser -set chrome
+```
 
 Running defaultbrowser without arguments shows the current setting.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ defaultbrowser -set chrome
 ```
 
 Running defaultbrowser without arguments shows the current setting.
+
+License
+-------
+
+MIT


### PR DESCRIPTION
Improved documentation, including recommendation to install into `/usr/local/bin/` which is more common than `~/bin/`.