### PR TITLE
Suggestion for the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ How does it work?
 
 The code uses the [macOS Launch Services API](https://developer.apple.com/documentation/coreservices/launch_services).
 
+Additional Resources
+--------------------
+
+- [Bash completion](https://github.com/jonasbn/bash_completion_defaultbrowser) for `defaultbrowser`
+
 License
 -------
 


### PR DESCRIPTION
This PR add new section and link to Bash completion implementation for defaultbrowser.

I know macOS now uses Zsh as the default shell, but for older versions and Bash users, this might prove useful.

If you think this does not bring any value to your documentation, please disregard it.

Thanks for a marvellous tool.
