### PR TITLE
Patch to mark Chrome browser

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -55,13 +55,13 @@ int main(int argc, const char *argv[]) {
         if (target == '\0') {
             // List all HTTP handlers, marking the current one with a star
             for (NSString *key in handlers) {
-                char *mark = [key isEqual:current_handler_name] ? "* " : "  ";
+                char *mark = [key caseInsensitiveCompare:current_handler_name] == NSOrderedSame ? "* " : "  ";
                 printf("%s%s\n", mark, [key UTF8String]);
             }
         } else {
             NSString *target_handler_name = [NSString stringWithUTF8String:target];
 
-            if ([target_handler_name isEqual:current_handler_name]) {
+            if ([target_handler_name caseInsensitiveCompare:current_handler_name] == NSOrderedSame) {
               printf("%s is already set as the default HTTP handler\n", target);
             } else {
                 NSString *target_handler = handlers[target_handler_name];


### PR DESCRIPTION
I experience that the Chrome browser is not marked when set as default browser.

With Firefix Developer Edition set as the default browser:

```
defaultbrowser
  iterm2
  browser
  kitty
  chrome
* firefoxdeveloperedition
  safari
```

With Chrome set as the default browser:

```
defaultbrowser
  iterm2
  browser
  kitty
  chrome
  firefoxdeveloperedition
  safari
```

So this patch implements case insensitive string comparison, since the comparisons of the strings: `chrome` and `Chrome` seems to be the issue.

Do not I am not an Objective-C programmer, so feel free to come with suggestions or edit the proposal or reject it all together.

The patch also enables the warning when attempting to set the Chrome browser as default twice, currently it is silent.