### PR TITLE
Improved error message for unrecognized handler

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -58,6 +58,7 @@ int main(int argc, const char *argv[]) {
                 char *mark = [key caseInsensitiveCompare:current_handler_name] == NSOrderedSame ? "* " : "  ";
                 printf("%s%s\n", mark, [key UTF8String]);
             }
+
         } else {
             NSString *target_handler_name = [NSString stringWithUTF8String:target];
 
@@ -71,7 +72,10 @@ int main(int argc, const char *argv[]) {
                     set_default_handler(@"http", target_handler);
                     set_default_handler(@"https", target_handler);
                 } else {
-                    printf("%s is not available as an HTTP handler\n", target);
+                    printf("%s is not available as an HTTP handler\n\nAvailable HTTP handlers are:\n", target);
+                    for (NSString *key in handlers) {
+                        printf("  %s\n", [key UTF8String]);
+                    }
 
                     return 1;
                 }


### PR DESCRIPTION
Hi @kerma 

I am working hard on getting my colleagues to dig more into good and useful error messages, so this is vary much on top of my mind these day and I can recommend this blog post:

- [When life gives you lemons, write better error messages](https://scribe.rip/when-life-gives-you-lemons-write-better-error-messages-46c5223e1a2f)

So this Saturday morning I was fooling around with `defaultbrowser` and it struck me, that the error message could be improved.

The error message proposed in this PR aims to tap into the following part from the linked article:

> Help them fix it: Tell them exactly what to do if there’s a way to possibly fix it.

When the handler is not recognized, a list of known handlers are appended to the error message indicating this, so the user can faster get to a resolution.

Example:

```shell
test is not available as an HTTP handler

Available HTTP handlers are:
  iterm2
  browser
  zen
  chrome
  firefoxdeveloperedition
  safari
```

Well whether you choose to take this into consideration or not is up to you, I just want to take the chance to thank you. You would not believe how much I use `defaultbrowser` every day.
