### PR TITLE
Attempt at solving issue with both Arc and Brave resolving to the same short name

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -70,7 +70,6 @@ int main(int argc, const char *argv[]) {
         if (target == '\0') {
             // List all HTTP handlers, marking the current one with a star
             for (NSString *key in handlers) {
-                NSString *value = handlers[key];
                 char *mark = [key caseInsensitiveCompare:current_handler_name] == NSOrderedSame ? "* " : "  ";
                 printf("%s%s\n", mark, [key UTF8String]);
             }

--- a/src/main.m
+++ b/src/main.m
@@ -58,7 +58,7 @@ void set_default_handler(NSString *url_scheme, NSString *handler) {
 }
 
 int main(int argc, const char *argv[]) {
-    NSString *target = (argc > 1) ? [NSString stringWithUTF8String:argv[1]] : nil;
+    const char *target = (argc == 1) ? '\0' : argv[1];
 
     @autoreleasepool {
         // Get all HTTP handlers

--- a/src/main.m
+++ b/src/main.m
@@ -7,7 +7,19 @@
 #import <ApplicationServices/ApplicationServices.h>
 
 NSString* app_name_from_bundle_id(NSString *app_bundle_id) {
-    return [[[app_bundle_id componentsSeparatedByString:@"."] lastObject] lowercaseString];
+
+    NSString *handler = app_bundle_id;
+    NSString *shortname = @"";
+
+    if ([handler caseInsensitiveCompare:@"company.thebrowser.Browser"] == NSOrderedSame) {
+        shortname = @"arc";
+    } else if ([handler caseInsensitiveCompare:@"com.brave.Browser"] == NSOrderedSame) {
+        shortname = @"brave";
+    } else {
+        shortname = [[[app_bundle_id componentsSeparatedByString:@"."] lastObject] lowercaseString];
+    }
+
+    return shortname;
 }
 
 NSMutableDictionary* get_http_handlers() {
@@ -20,7 +32,10 @@ NSMutableDictionary* get_http_handlers() {
 
     for (int i = 0; i < [handlers count]; i++) {
         NSString *handler = [handlers objectAtIndex:i];
-        dict[app_name_from_bundle_id(handler)] = handler;
+
+        NSString *shortname = app_name_from_bundle_id(handler);
+
+        dict[shortname] = handler;
     }
 
     return dict;
@@ -57,36 +72,21 @@ int main(int argc, const char *argv[]) {
             for (NSString *key in handlers) {
                 NSString *value = handlers[key];
                 char *mark = [key caseInsensitiveCompare:current_handler_name] == NSOrderedSame ? "* " : "  ";
-
-                if ([key caseInsensitiveCompare:@"browser"] == NSOrderedSame) {
-                    key = @"arc";
-                }
                 printf("%s%s\n", mark, [key UTF8String]);
             }
         } else {
-            NSString *display_name = [target copy];
-            NSString *lookup_name = [target copy];
 
-            // Convert arc/browser names for display and lookup
-            if ([target caseInsensitiveCompare:@"browser"] == NSOrderedSame) {
-                display_name = @"arc";
-                lookup_name = @"browser";
-            } else if ([target caseInsensitiveCompare:@"arc"] == NSOrderedSame) {
-                display_name = @"arc";
-                lookup_name = @"browser";
-            }
-
-            if ([lookup_name caseInsensitiveCompare:current_handler_name] == NSOrderedSame) {
-                printf("%s is already set as the default HTTP handler\n", [display_name UTF8String]);
+            if ([target caseInsensitiveCompare:current_handler_name] == NSOrderedSame) {
+                printf("%s is already set as the default HTTP handler\n", [target UTF8String]);
             } else {
-                NSString *target_handler = handlers[lookup_name];
+                NSString *target_handler = handlers[target];
 
                 if (target_handler != nil) {
                     // Set new HTTP handler (HTTP and HTTPS separately)
                     set_default_handler(@"http", target_handler);
                     set_default_handler(@"https", target_handler);
                 } else {
-                    printf("%s is not available as an HTTP handler\n", [display_name UTF8String]);
+                    printf("%s is not available as an HTTP handler\n", [target UTF8String]);
 
                     return 1;
                 }

--- a/src/main.m
+++ b/src/main.m
@@ -43,7 +43,7 @@ void set_default_handler(NSString *url_scheme, NSString *handler) {
 }
 
 int main(int argc, const char *argv[]) {
-    const char *target = (argc == 1) ? '\0' : argv[1];
+    NSString *target = (argc > 1) ? [NSString stringWithUTF8String:argv[1]] : nil;
 
     @autoreleasepool {
         // Get all HTTP handlers
@@ -52,26 +52,41 @@ int main(int argc, const char *argv[]) {
         // Get current HTTP handler
         NSString *current_handler_name = get_current_http_handler();
 
-        if (target == '\0') {
+        if (target == nil) {
             // List all HTTP handlers, marking the current one with a star
             for (NSString *key in handlers) {
+                NSString *value = handlers[key];
                 char *mark = [key caseInsensitiveCompare:current_handler_name] == NSOrderedSame ? "* " : "  ";
+
+                if ([key caseInsensitiveCompare:@"browser"] == NSOrderedSame) {
+                    key = @"arc";
+                }
                 printf("%s%s\n", mark, [key UTF8String]);
             }
         } else {
-            NSString *target_handler_name = [NSString stringWithUTF8String:target];
+            NSString *display_name = [target copy];
+            NSString *lookup_name = [target copy];
 
-            if ([target_handler_name caseInsensitiveCompare:current_handler_name] == NSOrderedSame) {
-              printf("%s is already set as the default HTTP handler\n", target);
+            // Convert arc/browser names for display and lookup
+            if ([target caseInsensitiveCompare:@"browser"] == NSOrderedSame) {
+                display_name = @"arc";
+                lookup_name = @"browser";
+            } else if ([target caseInsensitiveCompare:@"arc"] == NSOrderedSame) {
+                display_name = @"arc";
+                lookup_name = @"browser";
+            }
+
+            if ([lookup_name caseInsensitiveCompare:current_handler_name] == NSOrderedSame) {
+                printf("%s is already set as the default HTTP handler\n", [display_name UTF8String]);
             } else {
-                NSString *target_handler = handlers[target_handler_name];
+                NSString *target_handler = handlers[lookup_name];
 
                 if (target_handler != nil) {
                     // Set new HTTP handler (HTTP and HTTPS separately)
                     set_default_handler(@"http", target_handler);
                     set_default_handler(@"https", target_handler);
                 } else {
-                    printf("%s is not available as an HTTP handler\n", target);
+                    printf("%s is not available as an HTTP handler\n", [display_name UTF8String]);
 
                     return 1;
                 }

--- a/src/main.m
+++ b/src/main.m
@@ -67,7 +67,7 @@ int main(int argc, const char *argv[]) {
         // Get current HTTP handler
         NSString *current_handler_name = get_current_http_handler();
 
-        if (target == nil) {
+        if (target == '\0') {
             // List all HTTP handlers, marking the current one with a star
             for (NSString *key in handlers) {
                 NSString *value = handlers[key];


### PR DESCRIPTION
When going over some of the issues, I installed both Arc and Brave. Unfortunately they resolve to the same short name: `browser`.

- `com.brave.Browser (browser)`
- `com.googlecode.iterm2 (iterm2)`
- `com.google.Chrome (chrome)`
- `org.mozilla.firefoxdeveloperedition (firefoxdeveloperedition)`
- `com.apple.Safari (safari)`
- `app.zen-browser.zen (zen)`
- `company.thebrowser.Browser (browser)`

When I finally wrapped my head around the resolution of the short name. I thought it was an official name, see: #27, I could list and manipulate both browsers.

The solution is not optimal since it might invite into extending the list, but this PR is more of a suggestion to look into this since you might come up with a better long term solution.

Take care,

jonasbn

